### PR TITLE
iteration-004: caching weather

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,3 +30,12 @@ Style/Documentation:
 
 RSpec/NamedSubject:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/SubjectStub:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false

--- a/app/models/weather_service.rb
+++ b/app/models/weather_service.rb
@@ -7,34 +7,76 @@ class WeatherService
 
   CELSIUS_SCALE = "Celsius"
   FAHRENHEIT_SCALE = "Fahrenheit"
+  CACHE_TIMEOUT = 30.minutes
 
-  attr_reader :temp_scale, :temperature
+  attr_reader :temp_scale,       # Temperature scale to use, "Celsius" or "Fahrenheit"
+              :use_caching,      # Flag to determine if we should cache or not
+              :using_cache,      # Flag to tell if the value came from cache or hot
+              :cache_timeout,    # How long to set the cache timeout
+              :address,          # The address to use in the weather API query
+              :temperature       # The current temperature
 
+  validates :address, presence: true
   validates :temp_scale, presence: true, inclusion: { in: [CELSIUS_SCALE, FAHRENHEIT_SCALE] }
+
+  def self.current_temp_for(address, options = {})
+    new(options).current_temp_for(address)
+  end
+
   def initialize(options = {})
     @options = options
     @temp_scale = options.fetch(:temp_scale, FAHRENHEIT_SCALE)
+    @use_caching = options.fetch(:use_caching, false)
+    @cache_timeout = options.fetch(:cache_timeout, CACHE_TIMEOUT)
   end
 
   # @param [String] address: The string to pass to query the service
-  # @return [Boolean] the current temperature
+  # @return [WeatherService] the current temperature
   def current_temp_for(address)
-    return false unless valid?
+    @address = address
+    if valid?
+      if use_caching
+        cached_fetch
+      else
+        temp_fetch
+      end
+    else
+      @temperature = nil
+    end
+    self
+  rescue KeyError => e
+    errors.add(:base, e.message)
+    self
+  end
 
+  def success?
+    @temperature.present?
+  end
+  alias success success?
+
+  private
+
+  def cached_fetch
+    @using_cache = true
+    @temperature =
+      Rails.cache.fetch(cache_key, expires_in: cache_timeout) do
+        temp_fetch
+      end
+  end
+
+  def temp_fetch
+    @using_cache = false
     @temperature =
       if temp_scale == FAHRENHEIT_SCALE
         current(address).fetch("temp_f")
       elsif temp_scale == CELSIUS_SCALE
         current(address).fetch("temp_c")
       end
-
-    true
-  rescue KeyError => e
-    errors.add(:base, e.message)
-    false
   end
 
-  private
+  def cache_key
+    "weather_service/#{address}/#{temp_scale}"
+  end
 
   def current(address)
     client.current(address:).fetch("current")

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -31,7 +31,8 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  # config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/spec/models/weather_service_spec.rb
+++ b/spec/models/weather_service_spec.rb
@@ -4,34 +4,74 @@ require "rails_helper"
 
 RSpec.describe WeatherService do
   describe "#current_temp_for" do
-    context "when temp_scale is Celsius" do
-      let(:service) { described_class.new(temp_scale: "Celsius") }
+    context "when caching is off" do
+      context "when temp_scale is Celsius" do
+        let(:service) { described_class.new(temp_scale: "Celsius") }
 
-      before do
-        VCR.use_cassette "weather_service/current_temp_for/when_temp_scale_is_celsius" do
-          # NOTE: Sadly, this could be brittle, if the VCR cassette changes and the conditions are different
-          assert(service.current_temp_for("London"))
+        before do
+          VCR.use_cassette "weather_service/current_temp_for/when_temp_scale_is_celsius" do
+            # NOTE: Sadly, this could be brittle, if the VCR cassette changes and the conditions are different
+            assert(service.current_temp_for("London"))
+          end
+        end
+
+        it "returns the current temp in Celsius" do
+          expect(service.temperature).to eq(13.0)
         end
       end
 
-      it "returns the current temp in Celsius" do
-        expect(service.temperature).to eq(13.0)
+      context "when temp_scale is Fahrenheit" do
+        let(:service) { described_class.new(temp_scale: "Fahrenheit") }
+
+        before do
+          VCR.use_cassette "weather_service/current_temp_for/when_temp_scale_is_fahrenheit" do
+            # NOTE: Sadly, this could be brittle, if the VCR cassette changes and the conditions are different
+            assert(service.current_temp_for("London"))
+          end
+        end
+
+        it "returns the current temp in Fahrenheit" do
+          expect(service.temperature).to eq(55.4)
+        end
       end
     end
 
-    context "when temp_scale is Fahrenheit" do
-      let(:service) { described_class.new(temp_scale: "Fahrenheit") }
+    context "when caching is on" do
+      subject { described_class.new(options) }
+
+      let(:options) do
+        {
+          temp_scale: "Celsius",
+          use_caching: true
+        }
+      end
+      let(:fake_data) do
+        {
+          "temp_c" => 21.0,
+          "temp_f" => 69.8
+        }
+      end
 
       before do
-        VCR.use_cassette "weather_service/current_temp_for/when_temp_scale_is_fahrenheit" do
-          # NOTE: Sadly, this could be brittle, if the VCR cassette changes and the conditions are different
-          assert(service.current_temp_for("London"))
-        end
+        allow(subject).to receive(:current).once.and_return(fake_data)
+        subject.current_temp_for("Madrid")
       end
 
-      it "returns the current temp in Fahrenheit" do
-        expect(service.temperature).to eq(55.4)
+      it "using_cache should be false first time" do
+        expect(subject.using_cache).to be_falsy
       end
+
+      it "getting Madrid again should use cached value" do
+        subject.current_temp_for("Madrid")
+        expect(subject.using_cache).to be_truthy
+      end
+    end
+  end
+
+  describe "self.current_temp_for" do
+    it "calls #current_temp_for on an instance" do
+      expect_any_instance_of(described_class).to receive(:current_temp_for)
+      described_class.current_temp_for("London")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,6 +96,8 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  config.default_formatter = "doc"
 end
 
 VCR.configure do |vcr|


### PR DESCRIPTION
Added caching to the WeatherService class

- Using Rails cache
- For testing, needed to set the cache store to `:memory_store` in test environment. I don't think this does any harm in a small toy app like this, but there must be a way to turn on a useful cache store for a single test file.
- The RSpec rubocops are killing me. No one ever seems to present a real case for why things are good or bad.

